### PR TITLE
Prevent Opening Links in Same Tab inside Editor

### DIFF
--- a/app/assets/javascripts/pageflow/external_links/editor/templates/embedded/list_item.jst.ejs
+++ b/app/assets/javascripts/pageflow/external_links/editor/templates/embedded/list_item.jst.ejs
@@ -3,3 +3,7 @@
   <p class="link-title"></p>
   <p class="link-description"></p>
 </div>
+<div class="tooltip">
+  Öffnen im selben Tab ist im Editor deaktiviert.
+  <span target="_blank">Seite in neuem Tab ansehen</span>
+</div>

--- a/app/assets/javascripts/pageflow/external_links/editor/views/embedded/list_item_embedded_view.js
+++ b/app/assets/javascripts/pageflow/external_links/editor/views/embedded/list_item_embedded_view.js
@@ -7,7 +7,30 @@ pageflow.externalLinks.ListItemEmbeddedView = Backbone.Marionette.ItemView.exten
   ui: {
     title: '.link-title',
     description: '.link-description',
-    thumbnail: '.link-thumbnail'
+    thumbnail: '.link-thumbnail',
+    tooltip: '.tooltip'
+  },
+
+  events: {
+    'click': function(event) {
+      if (event.currentTarget.target) {
+        event.stopPropagation();
+      }
+      else {
+        this.ui.tooltip.show();
+        return false;
+      }
+    },
+
+    'mouseleave': function() {
+      this.ui.tooltip.hide();
+    },
+
+    'click .tooltip': function() {
+      window.open(this.$el.attr('href'), '_blank');
+      this.ui.tooltip.hide();
+      return false;
+    }
   },
 
   onRender: function() {
@@ -20,11 +43,12 @@ pageflow.externalLinks.ListItemEmbeddedView = Backbone.Marionette.ItemView.exten
 
     this.ui.title.text(site.get('title'));
     this.ui.description.html(site.get('description'));
+    this.ui.tooltip.hide();
 
     this.$el.toggleClass('no_text', blank(site.get('title')) && blank(site.get('description')));
 
     this.$el.attr('href', site.get('url'));
-    this.$el.attr('blank', site.get('open_in_new_tab') ? '_blank' : null);
+    this.$el.attr('target', site.get('open_in_new_tab') ? '_blank' : null);
 
     this.updateThumbnailView(site);
 

--- a/app/assets/stylesheets/pageflow/external_links.css.scss
+++ b/app/assets/stylesheets/pageflow/external_links.css.scss
@@ -90,6 +90,7 @@
 
   .link-item {
     display: inline-block;
+    position: relative;
     width: 24%;
     width: 250px;
     background-color: rgb(20,20,20);

--- a/app/assets/stylesheets/pageflow/external_links/editor.css.scss
+++ b/app/assets/stylesheets/pageflow/external_links/editor.css.scss
@@ -1,3 +1,5 @@
+@import "./editor/embedded";
+
 .editor {
 .manage_external_sites {
   a.add {

--- a/app/assets/stylesheets/pageflow/external_links/editor/embedded.css.scss
+++ b/app/assets/stylesheets/pageflow/external_links/editor/embedded.css.scss
@@ -1,0 +1,24 @@
+.ext-links {
+  .tooltip {
+    position: absolute;
+    left: 50%;
+    top: 102px;
+    width: 180px;
+    padding: 5px;
+    margin-left: -95px;
+
+    background-color: #444;
+    color: #fff;
+    border: solid 1px #fff;
+    opacity: 0.7;
+    font-size: 13px;
+    text-align: center;
+    white-space: normal;
+
+    span {
+      display: block;
+      color: #fff;
+      text-decoration: underline;
+    }
+  }
+}


### PR DESCRIPTION
Instead display a little tooltip offering to view page in new tab
instead.