### PR TITLE
Turn Site Url Attribute into Text Column

### DIFF
--- a/db/migrate/20141218183701_change_site_url_to_text.rb
+++ b/db/migrate/20141218183701_change_site_url_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeSiteUrlToText < ActiveRecord::Migration
+  def change
+    change_column(:pageflow_external_links_sites, :url, :text)
+  end
+end


### PR DESCRIPTION
Urls can be long.