### PR TITLE
Prevent Nested Links in Items

### DIFF
--- a/app/views/pageflow/external_links/sites/_site.html.erb
+++ b/app/views/pageflow/external_links/sites/_site.html.erb
@@ -5,6 +5,6 @@
   <%= content_tag(:div, '', class: external_links_site_thumbnail_css_class(site)) %>
   <div class="link-details">
     <p class="link-title"><%= site.title %></p>
-    <p class="link-description"><%= raw(site.description) %></p>
+    <p class="link-description"><%= raw(strip_links(site.description)) %></p>
   </div>
 <% end %>


### PR DESCRIPTION
Breaks layout outside of editor.