### PR TITLE
Add .idea entry to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .bundle
 .config
 .yardoc
+.idea
 InstalledFiles
 _yardoc
 coverage


### PR DESCRIPTION
Exclude project files created by Jetbrains IDEs.