### PR TITLE
Flexible height for link boxes

### DIFF
--- a/app/assets/javascripts/pageflow/external_links/editor/views/embedded/list_embedded_view.js
+++ b/app/assets/javascripts/pageflow/external_links/editor/views/embedded/list_embedded_view.js
@@ -10,6 +10,10 @@ pageflow.externalLinks.ListEmbeddedView = Backbone.Marionette.View.extend({
       this.refreshScroller();
     });
 
+    this.listenTo(pageflow.externalLinks.sites, 'change', function() {
+      this.$el.data('scroller').updateHeight();
+    });
+
     this.refreshScroller();
 
     return this;
@@ -18,5 +22,6 @@ pageflow.externalLinks.ListEmbeddedView = Backbone.Marionette.View.extend({
   refreshScroller: function() {
     this.$el.data('scroller').refresh();
     this.$el.data('scroller').checkDisable();
+    this.$el.data('scroller').updateHeight();
   }
 });

--- a/app/assets/javascripts/pageflow/external_links/page_type.js
+++ b/app/assets/javascripts/pageflow/external_links/page_type.js
@@ -9,7 +9,7 @@ pageflow.pageType.register('external_links', _.extend({
         innerScroller = pageElement.find('#horizontal_scroller'),
         contentWrapper = pageElement.find('.contentWrapper');
 
-    this.scroller = new IScroll(scrollerElement[0], {
+    this.linkScroller = new IScroll(scrollerElement[0], {
       mouseWheel: true,
       bounce: false,
       keyBindings: true,
@@ -19,68 +19,68 @@ pageflow.pageType.register('external_links', _.extend({
       eventPassthrough: true
     });
 
-    this.scroller.checkDisable = function() {
+    this.linkScroller.checkDisable = function() {
       that._checkForIScroll(scrollerElement, innerScroller, pageElement.find('.arrow-forward'), pageElement.find('.arrow-back'), pageElement);
     };
-    scrollerElement.data('scroller', this.scroller);
+    scrollerElement.data('scroller', this.linkScroller);
 
-    that.scroller.on('scroll', function() {
-      that.scroller.checkDisable();
+    that.linkScroller.on('scroll', function() {
+      that.linkScroller.checkDisable();
     });
 
     /* Arrows for Gallery */
 
     pageElement.find('.arrow-back').on('click', function(e) {
-      var nextElement = Math.round((that.scroller.x / -260) - (scrollerElement.width() / 260 / 2), 10);
+      var nextElement = Math.round((that.linkScroller.x / -260) - (scrollerElement.width() / 260 / 2), 10);
       if (nextElement <= 1) {
-        that.scroller.scrollTo(0, 0, 500, IScroll.ease.quadratic);
+        that.linkScroller.scrollTo(0, 0, 500, IScroll.ease.quadratic);
       }
       else {
-        that.scroller.scrollToElement($(".page.active #horizontal_scroller a")[nextElement], 500, 0, 0, IScroll.ease.quadratic);
+        that.linkScroller.scrollToElement($(".page.active #horizontal_scroller a")[nextElement], 500, 0, 0, IScroll.ease.quadratic);
       }
-      that.scroller.checkDisable();
+      that.linkScroller.checkDisable();
       e.stopPropagation();
       return false;
     });
 
     pageElement.find('.arrow-forward').on('click', function(e) {
-      var nextElement = Math.round((that.scroller.x / -260) + (scrollerElement.width() / 260 / 2), 10);
+      var nextElement = Math.round((that.linkScroller.x / -260) + (scrollerElement.width() / 260 / 2), 10);
       if (nextElement == innerScroller.find('a').length - 1) {
-        that.scroller.scrollTo(that.scroller.maxScrollX, 0, 500, IScroll.ease.quadratic);
+        that.linkScroller.scrollTo(that.linkScroller.maxScrollX, 0, 500, IScroll.ease.quadratic);
       }
       else {
-        that.scroller.scrollToElement($(".page.active #horizontal_scroller a")[nextElement]);
+        that.linkScroller.scrollToElement($(".page.active #horizontal_scroller a")[nextElement]);
       }
-      that.scroller.checkDisable();
+      that.linkScroller.checkDisable();
       e.stopPropagation();
       return false;
     });
   },
 
   resize: function(pageElement, configuration) {
-    this.scroller.refresh();
-    this.scroller.checkDisable();
+    this.linkScroller.refresh();
+    this.linkScroller.checkDisable();
   },
 
   _checkForIScroll: function(outerElement, innerElement, arrowForward, arrowBack, pageElement) {
     if (pageElement.width() <= 700) {
-      this.scroller.disable();
+      this.linkScroller.disable();
     }
     else {
       if (innerElement.width() <= outerElement.width()) {
-        this.scroller.disable();
+        this.linkScroller.disable();
         arrowForward.css('display', 'none');
         arrowBack.css('display', 'none');
       }
       else {
-        this.scroller.enable();
-        if (this.scroller.x == this.scroller.maxScrollX) {
+        this.linkScroller.enable();
+        if (this.linkScroller.x == this.linkScroller.maxScrollX) {
           arrowForward.css('display', 'none');
         }
         else {
           arrowForward.css('display', 'block');
         }
-        if (this.scroller.x === 0) {
+        if (this.linkScroller.x === 0) {
           arrowBack.css('display', 'none');
         }
         else {
@@ -98,8 +98,8 @@ pageflow.pageType.register('external_links', _.extend({
   },
 
   activating: function(pageElement, configuration) {
-    this.scroller.refresh();
-    this.scroller.checkDisable();
+    this.linkScroller.refresh();
+    this.linkScroller.checkDisable();
   },
 
   activated: function(pageElement, configuration) {
@@ -122,8 +122,9 @@ pageflow.pageType.register('external_links', _.extend({
     pageElement.find('.shadow').css({
       opacity: configuration.get('gradient_opacity') / 100
     });
-    this.scroller.refresh();
-    this.scroller.checkDisable();
+
+    this.linkScroller.refresh();
+    this.linkScroller.checkDisable();
   },
 
   embeddedEditorViews: function() {

--- a/app/assets/javascripts/pageflow/external_links/page_type.js
+++ b/app/assets/javascripts/pageflow/external_links/page_type.js
@@ -5,9 +5,9 @@ pageflow.pageType.register('external_links', _.extend({
 
   enhance: function(pageElement, configuration) {
     var scrollerElement = pageElement.find('.ext-links'),
-    that = this,
-    innerScroller = pageElement.find('#horizontal_scroller'),
-    contentWrapper = pageElement.find('.contentWrapper');
+        that = this,
+        innerScroller = pageElement.find('#horizontal_scroller'),
+        contentWrapper = pageElement.find('.contentWrapper');
 
     this.scroller = new IScroll(scrollerElement[0], {
       mouseWheel: true,
@@ -28,12 +28,11 @@ pageflow.pageType.register('external_links', _.extend({
       that.scroller.checkDisable();
     });
 
-
     /* Arrows for Gallery */
 
     pageElement.find('.arrow-back').on('click', function(e) {
-      var nextElement = Math.round((that.scroller.x / - 260) - (scrollerElement.width() / 260 / 2), 10);
-      if(nextElement <= 1 ) {
+      var nextElement = Math.round((that.scroller.x / -260) - (scrollerElement.width() / 260 / 2), 10);
+      if (nextElement <= 1) {
         that.scroller.scrollTo(0, 0, 500, IScroll.ease.quadratic);
       }
       else {
@@ -45,8 +44,8 @@ pageflow.pageType.register('external_links', _.extend({
     });
 
     pageElement.find('.arrow-forward').on('click', function(e) {
-      var nextElement = Math.round((that.scroller.x / - 260) + (scrollerElement.width() / 260 / 2), 10);
-      if(nextElement == innerScroller.find('a').length -1 ) {
+      var nextElement = Math.round((that.scroller.x / -260) + (scrollerElement.width() / 260 / 2), 10);
+      if (nextElement == innerScroller.find('a').length - 1) {
         that.scroller.scrollTo(that.scroller.maxScrollX, 0, 500, IScroll.ease.quadratic);
       }
       else {
@@ -64,28 +63,28 @@ pageflow.pageType.register('external_links', _.extend({
   },
 
   _checkForIScroll: function(outerElement, innerElement, arrowForward, arrowBack, pageElement) {
-    if(pageElement.width() <= 700) {
+    if (pageElement.width() <= 700) {
       this.scroller.disable();
     }
     else {
-      if(innerElement.width() <= outerElement.width()) {
+      if (innerElement.width() <= outerElement.width()) {
         this.scroller.disable();
-        arrowForward.css('display','none');
-        arrowBack.css('display','none');
+        arrowForward.css('display', 'none');
+        arrowBack.css('display', 'none');
       }
       else {
         this.scroller.enable();
-        if(this.scroller.x == this.scroller.maxScrollX) {
-          arrowForward.css('display','none');
+        if (this.scroller.x == this.scroller.maxScrollX) {
+          arrowForward.css('display', 'none');
         }
         else {
-          arrowForward.css('display','block');
+          arrowForward.css('display', 'block');
         }
-        if(this.scroller.x === 0) {
-          arrowBack.css('display','none');
+        if (this.scroller.x === 0) {
+          arrowBack.css('display', 'none');
         }
         else {
-          arrowBack.css('display','block');
+          arrowBack.css('display', 'block');
         }
       }
     }
@@ -106,9 +105,11 @@ pageflow.pageType.register('external_links', _.extend({
   activated: function(pageElement, configuration) {
   },
 
-  deactivating: function(pageElement, configuration) {},
+  deactivating: function(pageElement, configuration) {
+  },
 
-  deactivated: function(pageElement, configuration) {},
+  deactivated: function(pageElement, configuration) {
+  },
 
   update: function(pageElement, configuration) {
     pageElement.find('h2 .tagline').text(configuration.get('tagline') || '');

--- a/app/assets/javascripts/pageflow/external_links/page_type.js
+++ b/app/assets/javascripts/pageflow/external_links/page_type.js
@@ -22,6 +22,11 @@ pageflow.pageType.register('external_links', _.extend({
     this.linkScroller.checkDisable = function() {
       that._checkForIScroll(scrollerElement, innerScroller, pageElement.find('.arrow-forward'), pageElement.find('.arrow-back'), pageElement);
     };
+
+    this.linkScroller.updateHeight = function() {
+      that._adjustHeight(pageElement);
+    };
+
     scrollerElement.data('scroller', this.linkScroller);
 
     that.linkScroller.on('scroll', function() {
@@ -90,6 +95,15 @@ pageflow.pageType.register('external_links', _.extend({
     }
   },
 
+  _adjustHeight: function(pageElement) {
+    var element = pageElement.find('.ext-links');
+    var child = pageElement.find('.ext-links > div');
+
+    element.height(child.height());
+
+    this.scroller.refresh();
+  },
+
   prepare: function(pageElement, configuration) {
   },
 
@@ -103,6 +117,7 @@ pageflow.pageType.register('external_links', _.extend({
   },
 
   activated: function(pageElement, configuration) {
+    this._adjustHeight(pageElement);
   },
 
   deactivating: function(pageElement, configuration) {

--- a/app/assets/stylesheets/pageflow/external_links.css.scss
+++ b/app/assets/stylesheets/pageflow/external_links.css.scss
@@ -9,7 +9,7 @@
     @include transition(opacity 0.5s);
 
     .hideText & {
-      @include transform(translate(-100%,0));
+      @include transform(translate(-100%, 0));
     }
 
     @include phone {
@@ -53,7 +53,6 @@
       }
     }
 
-
     @include phone {
       display: none !important;
     }
@@ -91,10 +90,9 @@
   .link-item {
     display: inline-block;
     position: relative;
-    width: 24%;
     width: 250px;
-    background-color: rgb(20,20,20);
-    background-color: rgba(20,20,20, 0.8);
+    background-color: rgb(20, 20, 20);
+    background-color: rgba(20, 20, 20, 0.8);
     vertical-align: top;
     max-height: 400px;
     height: 400px;
@@ -115,7 +113,7 @@
 
     &:hover {
       text-decoration: underline;
-      background-color: rgba(20,20,20, 1);
+      background-color: rgba(20, 20, 20, 1);
       @include transform(scale(1.05));
 
       @include phone {
@@ -124,7 +122,6 @@
     }
     @include phone {
       width: 230px;
-      margin-right: 0;
       margin-bottom: 10px;
       height: 290px;
       max-height: 290px;

--- a/app/assets/stylesheets/pageflow/external_links.css.scss
+++ b/app/assets/stylesheets/pageflow/external_links.css.scss
@@ -3,7 +3,6 @@
 .external-links-page {
 
   .ext-links {
-    height: 400px;
     pointer-events: all;
     position: relative;
     @include transition(opacity 0.5s);
@@ -14,6 +13,14 @@
 
     @include phone {
       height: auto;
+    }
+
+    > div {
+      @include desktop {
+        display: table;
+        border-collapse: separate;
+        border-spacing: 10px;
+      }
     }
   }
 
@@ -94,14 +101,16 @@
     background-color: rgb(20, 20, 20);
     background-color: rgba(20, 20, 20, 0.8);
     vertical-align: top;
-    max-height: 400px;
-    height: 400px;
     overflow: hidden;
     text-align: left;
     margin-right: 10px;
     text-decoration: none;
     color: white;
     @include transition(0.3s);
+
+    @include desktop {
+      display: table-cell;
+    }
 
     &.no_text {
       height: auto;
@@ -123,8 +132,6 @@
     @include phone {
       width: 230px;
       margin-bottom: 10px;
-      height: 290px;
-      max-height: 290px;
       margin-right: 5px;
       margin-left: 5px;
     }
@@ -135,9 +142,13 @@
     .link-thumbnail {
       background-repeat: no-repeat;
       background-size: cover;
-      width: 100%;
       padding-top: 56.25%;
       position: relative;
+      width: 250px;
+
+      @include phone {
+        width: 230px;
+      }
 
       .file_thumbnail {
         background-size: cover;

--- a/app/assets/stylesheets/pageflow/external_links.css.scss
+++ b/app/assets/stylesheets/pageflow/external_links.css.scss
@@ -98,6 +98,7 @@
     display: inline-block;
     position: relative;
     width: 250px;
+    max-width: 250px;
     background-color: rgb(20, 20, 20);
     background-color: rgba(20, 20, 20, 0.8);
     vertical-align: top;
@@ -131,6 +132,7 @@
     }
     @include phone {
       width: 230px;
+      max-width: 230px;
       margin-bottom: 10px;
       margin-right: 5px;
       margin-left: 5px;
@@ -174,9 +176,7 @@
       .link-title {
         font-size: 1.2em;
         font-weight: bold;
-        text-overflow: ellipsis;
         width: 100%;
-        white-space: nowrap;
         overflow: hidden;
       }
     }


### PR DESCRIPTION
Use display table-cell to ensure all items have the same height on desktop. Set height via js.

* Adjust height on activated hook
* Adjust height after link list has been changed in editor
* Adjust height when any site changes

Also allow multi link titles.