### PR TITLE
Disable links inside link description

### DIFF
--- a/app/assets/javascripts/pageflow/external_links/editor/views/edit_site_view.js
+++ b/app/assets/javascripts/pageflow/external_links/editor/views/edit_site_view.js
@@ -40,7 +40,10 @@ pageflow.externalLinks.EditSiteView = Backbone.Marionette.Layout.extend({
       this.input('title', pageflow.TextInputView, {
         required: true
       });
-      this.input('description', pageflow.TextAreaInputView, {size: 'short'});
+      this.input('description', pageflow.TextAreaInputView, {
+        size: 'short',
+        disableLinks: true
+      });
     });
 
     if (this.options.returnTo === 'page' && this.options.page) {


### PR DESCRIPTION
The items are links themselves. Links inside links are not allowed.