### PR TITLE
Add page type picotgram call to legacy theme

### DIFF
--- a/app/assets/stylesheets/pageflow/external_links/themes/legacy.scss
+++ b/app/assets/stylesheets/pageflow/external_links/themes/legacy.scss
@@ -1,3 +1,5 @@
+@include pageflow-page-type-pictograms("external_links");
+
 .external-links-page {
   .arrow-forward, .arrow-back {
     text-decoration: none;


### PR DESCRIPTION
Pageflow 0.10 already supports page type pictogram theme mixins.