### PR TITLE
Mention legacy theme in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Include javascripts and stylesheets:
     # app/assets/stylesheets/pageflow/editor.css.scss
     @import "pageflow/external_links/editor";
 
+If you are using Sass < 3.4, import the legacy theme:
+
+    # app/assets/stylesheets/pageflow/themes/default.css.scss
+    @import "pageflow/external_links/themes/legacy";
+    
+With Sass 3.4 or newer, you can use the default theme:
+
     # app/assets/stylesheets/pageflow/themes/default.css.scss
     @import "pageflow/external_links/themes/default";
 


### PR DESCRIPTION
To use `themes/default.scss`, Sass 3.4 and the (yet unreleased) configurable Pageflow default theme are required. Since the Sass update for Pageflow will happen together with the introduction of the configurable default theme, we only mention the Sass version requirement here.

fixes #27