### PR TITLE
rename imagePositioning to positioning

### DIFF
--- a/app/assets/javascripts/pageflow/external_links/editor/views/configuration_editor.js
+++ b/app/assets/javascripts/pageflow/external_links/editor/views/configuration_editor.js
@@ -8,7 +8,7 @@ pageflow.ConfigurationEditorView.register('external_links', {
       this.input('background_image_id', pageflow.FileInputView, {collection: pageflow.imageFiles});
       this.input('thumbnail_image_id', pageflow.FileInputView, {
         collection: pageflow.imageFiles,
-        imagePositioning: false
+        positioning: false
       });
     });
 

--- a/app/assets/javascripts/pageflow/external_links/editor/views/edit_site_view.js
+++ b/app/assets/javascripts/pageflow/external_links/editor/views/edit_site_view.js
@@ -35,7 +35,7 @@ pageflow.externalLinks.EditSiteView = Backbone.Marionette.Layout.extend({
           pageId: options.page && options.page.id,
           returnTo: options.returnTo
         },
-        imagePositioning: false
+        positioning: false
       });
       this.input('title', pageflow.TextInputView, {
         required: true


### PR DESCRIPTION
The option has been renamed a long time ago and obviously nobody has
noticed the remaining usage of the old name here.

fixes #29