### PR TITLE
Move page type registration into plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this line to your application's `Gemfile`:
 Register the page type inside the configure block in `config/initializers/pageflow.rb`
 
     Pageflow.configure do |config|
-      config.page_types.register(Pageflow::ExternalLinks.page_type)
+      config.plugin(Pageflow::ExternalLinks.plugin)
     end
 
 Include javascripts and stylesheets:

--- a/lib/pageflow/external_links/plugin.rb
+++ b/lib/pageflow/external_links/plugin.rb
@@ -2,6 +2,7 @@ module Pageflow
   module ExternalLinks
     class Plugin < Pageflow::Plugin
       def configure(config)
+        config.page_types.register(ExternalLinks.page_type)
         config.help_entries.register('pageflow.external_links.help_entries.sites', priority: 49)
       end
     end


### PR DESCRIPTION
Before the page type had to be registered separately. This is a
breaking change since manual page type registration has to be removed.q