### PR TITLE
Prevent error with missing site urls in Pageflow 15.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in chart.gemspec
 gemspec
+
+# Give a hint to Bundler to prevent endless loop
+gem 'rails', '~> 5.2.0'

--- a/Gemfile.ci
+++ b/Gemfile.ci
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pageflow-theme-doc-publisher', git: 'https://github.com/tf/pageflow-theme-doc-publisher'
+
+# Give a hint to Bundler to prevent endless loop
+gem 'rails', '~> 5.2.0'

--- a/app/views/pageflow/external_links/sites/_site.html.erb
+++ b/app/views/pageflow/external_links/sites/_site.html.erb
@@ -1,4 +1,4 @@
-<%= link_to(site.url,
+<%= link_to(site.url || '',
             class: external_links_site_css_class(site),
             target: site.open_in_new_tab? ? '_blank' : nil) do %>
 

--- a/lib/generators/pageflow_external_links/install/install_generator.rb
+++ b/lib/generators/pageflow_external_links/install/install_generator.rb
@@ -1,5 +1,30 @@
 module PageflowExternalLinks
-  class InstallGenerator < Pageflow::PageTypeInstallGenerator
+  class InstallGenerator < Rails::Generators::Base
+    desc 'Install the Pageflow plugin and the necessary migrations.'
+
+    def register_plugin
+      inject_into_file('config/initializers/pageflow.rb',
+                       after: "Pageflow.configure do |config|\n") do
+
+        "  config.plugin(Pageflow::#{engine_name_suffix.camelize}.plugin)\n"
+      end
+    end
+
+    def mount_engine
+      route("mount #{engine.name}, at: '/#{engine_name_suffix}'\n")
+    end
+
+    def install_migrations
+      rake "pageflow_#{engine_name_suffix}:install:migrations"
+      rake 'pageflow_external_links:install:migrations'
+    end
+
+    private
+
+    def engine_name_suffix
+      engine.engine_name.gsub(/^pageflow_/, '')
+    end
+
     def engine
       Pageflow::ExternalLinks::Engine
     end

--- a/spec/integration/page_type_spec.rb
+++ b/spec/integration/page_type_spec.rb
@@ -2,3 +2,49 @@ require 'spec_helper'
 require 'pageflow/lint'
 
 Pageflow::Lint.page_type(Pageflow::ExternalLinks.page_type)
+
+module Pageflow
+  module ExternalLinks
+    describe 'built in video page type', type: :helper do
+      include RenderPageTestHelper
+
+      it 'renders links to referenced sites' do
+        revision = FactoryBot.create(:revision, :published)
+        Site.create!(revision: revision,
+                     perma_id: 10,
+                     url: 'https://example.com',
+                     title: 'Example')
+
+        page = FactoryBot.create(:page,
+                                 template: 'external_links',
+                                 revision: revision,
+                                 configuration: {
+                                   linked_external_site_perma_ids: [10]
+                                 })
+
+        html = render_page(page)
+
+        expect(html).to have_selector('.link-title', text: 'Example')
+      end
+
+      it 'can handle sites with missing url' do
+        revision = FactoryBot.create(:revision, :published)
+        Site.create!(revision: revision,
+                     perma_id: 10,
+                     url: nil,
+                     title: 'Example')
+
+        page = FactoryBot.create(:page,
+                                 template: 'external_links',
+                                 revision: revision,
+                                 configuration: {
+                                   linked_external_site_perma_ids: [10]
+                                 })
+
+        html = render_page(page)
+
+        expect(html).to have_selector('.link-title', text: 'Example')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since the extraction of the paged entry type into a separate engine,
calling `link_to` with nil for a URL causes an error. Rails tries to
turn an empty hash into a route. This no longer works inside the paged
engine, since it only contains editor related routes.

As a workaround, default to an empty string. This leads to the same
behavior as before: Creating a link to the current location.

Extend CI setup to make sure the site renders in cases like this.

REDMINE-17412