### PR TITLE
Prefix ExternalLink::Site to prevent referencing Pageflow::Site (2.4 Backport)

### DIFF
--- a/lib/pageflow/external_links/page_type.rb
+++ b/lib/pageflow/external_links/page_type.rb
@@ -4,11 +4,11 @@ module Pageflow
       name 'external_links'
 
       def revision_components
-        [Site]
+        [ExternalLinks::Site]
       end
 
       def view_helpers
-        [SitesHelper]
+        [ExternalLinks::SitesHelper]
       end
     end
   end


### PR DESCRIPTION
Pageflow added its own `Site` model in 16.0. We need to make sure
autoloading still loads the correct model.

REDMINE-20103
